### PR TITLE
chore: add all test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,57 +1,122 @@
 mod lib_dir_file;
 
-use lib_dir_file::FileSystem;
-use std::path::Path;
+fn main() {
+    let filename = "filesystem.json";
+    let fs = filesystem_service::initialize_filesystem(filename);
 
-fn initialize_filesystem(filename: &str) -> FileSystem {
-    if Path::new(filename).exists() {
-        FileSystem::load_from_file(filename).expect("Failed to load filesystem")
-    } else {
-        let mut fs = FileSystem::new();
+    println!("{:#?}", fs);
+}
 
-        fs.create_directory("/", "root");
+mod filesystem_service {
+    use std::path::Path;
+    use crate::lib_dir_file::FileSystem;
 
-        fs.create_directory("/", "home");
-        fs.create_directory("/home", "cnino");
+    pub fn initialize_filesystem(filename: &str) -> FileSystem {
+        if Path::new(filename).exists() {
+            FileSystem::load_from_file(filename).expect("Failed to load filesystem")
+        } else {
+            let mut fs = FileSystem::new();
 
-        fs.create_directory("/", "boot");
+            fs.create_directory("/", "root");
 
-        fs.create_directory("/", "bin");
+            fs.create_directory("/", "home");
+            fs.create_directory("/home", "cnino");
 
-        fs.create_directory("/", "sbin");
+            fs.create_directory("/", "boot");
 
-        fs.create_directory("/", "sys");
+            fs.create_directory("/", "bin");
 
-        fs.create_directory("/", "etc");
-        fs.create_directory("/etc", "init");
-        fs.create_directory("/etc", "init.d");
+            fs.create_directory("/", "sbin");
 
-        fs.create_directory("/", "usr");
-        fs.create_directory("/", "dev");
-        fs.create_directory("/", "media");
-        fs.create_directory("/", "opt");
-        fs.create_directory("/", "tmp");
-        fs.create_directory("/", "var");
-        fs.create_directory("/var", "www");
-        fs.create_directory("/var/www", "html");
+            fs.create_directory("/", "sys");
 
-        // Create files
-        fs.create_file("/home/cnino", ".profile", b"export='$PATH=$PATH'".to_vec());
+            fs.create_directory("/", "etc");
+            fs.create_directory("/etc", "init");
+            fs.create_directory("/etc", "init.d");
 
-        fs.create_file(
-            "/var/www/html",
-            "index.php",
-            b"<?php echo('Hola') ?>".to_vec(),
-        );
+            fs.create_directory("/", "usr");
+            fs.create_directory("/", "dev");
+            fs.create_directory("/", "media");
+            fs.create_directory("/", "opt");
+            fs.create_directory("/", "tmp");
+            fs.create_directory("/", "var");
+            fs.create_directory("/var", "www");
+            fs.create_directory("/var/www", "html");
 
-        fs.save_to_file(filename).expect("Failed to save filesystem");
-        fs
+            // Create files
+            fs.create_file("/home/cnino", ".profile", b"export='$PATH=$PATH'".to_vec());
+
+            fs.create_file(
+                "/var/www/html",
+                "index.php",
+                b"<?php echo('Hola') ?>".to_vec(),
+            );
+
+            fs.save_to_file(filename).expect("Failed to save filesystem");
+            fs
+        }
     }
 }
 
-fn main() {
-    let filename = "filesystem.json";
-    let fs = initialize_filesystem(filename);
+#[cfg(test)]
+mod tests {
+    use super::filesystem_service;
+    use std::path::Path;
+    use std::fs;
 
-    println!("{:#?}", fs);
+    fn setup(test_filename: &str) {
+        if Path::new(test_filename).exists() {
+            fs::remove_file(test_filename).expect("Failed to delete existing test file");
+        }
+    }
+
+    fn cleanup(test_filename: &str) {
+        if Path::new(test_filename).exists() {
+            fs::remove_file(test_filename).expect("Failed to delete test file");
+        }
+    }
+
+    #[test]
+    fn test_initialize_filesystem_creates_new() {
+        let test_filename = "test_initialize_filesystem_creates_new.json";
+        setup(test_filename);
+
+        let fs = filesystem_service::initialize_filesystem(test_filename);
+
+        // Verificar que el archivo se creó
+        assert!(Path::new(test_filename).exists(), "File was not created");
+
+        // Verificar el contenido del sistema de archivos
+        assert!(fs.root.directories.contains_key("home"));
+        assert!(fs.root.directories.get("home").unwrap().directories.contains_key("cnino"));
+
+        cleanup(test_filename);
+    }
+
+    #[test]
+    fn test_initialize_filesystem_loads_existing() {
+        let test_filename = "test_initialize_filesystem_loads_existing.json";
+        setup(test_filename);
+
+        // Create a filesystem and save it
+        {
+            let mut fs = filesystem_service::initialize_filesystem(test_filename);
+            fs.create_file("/home/cnino", "testfile.txt", b"test content".to_vec());
+            fs.save_to_file(test_filename).expect("Failed to save filesystem");
+        }
+
+        // Verificar que el archivo se creó
+        assert!(Path::new(test_filename).exists(), "File was not created");
+
+        // Load the filesystem and check the contents
+        let fs = filesystem_service::initialize_filesystem(test_filename);
+        let home_dir = fs.root.directories.get("home").unwrap();
+        let cnino_dir = home_dir.directories.get("cnino").unwrap();
+        let test_file = cnino_dir.files.get("testfile.txt").unwrap();
+
+        assert_eq!(test_file.name, "testfile.txt");
+        assert_eq!(test_file.content, b"test content");
+
+        cleanup(test_filename);
+    }
 }


### PR DESCRIPTION
# Pull Request: Add Tests for `lib_dir_file.rs` and `initialize_filesystem` Function

## Description

This pull request adds unit tests for the `lib_dir_file.rs` module and the `initialize_filesystem` function in `main.rs`. The tests ensure that the core functionality of the in-memory filesystem works correctly and that the filesystem is correctly initialized, saved, and loaded.

## Changes

### `lib_dir_file.rs`
- Added tests for creating files and directories.
- Added tests for saving and loading the filesystem state.
- Ensured that each test uses a unique filename to avoid conflicts.

### `main.rs`
- Added a `filesystem_service` module to encapsulate the `initialize_filesystem` function.
- Added tests for `initialize_filesystem` to check:
  - The creation of a new filesystem when the file does not exist.
  - Loading an existing filesystem from a file.
- Used unique filenames for each test to avoid conflicts.

### Tests Added
- `lib_dir_file.rs`
  - `test_create_file`: Tests creating a file in a directory.
  - `test_create_directory`: Tests creating nested directories.
  - `test_save_and_load_filesystem`: Tests saving the filesystem state to a file and loading it back.

- `main.rs`
  - `test_initialize_filesystem_creates_new`: Tests that a new filesystem is created when the file does not exist.
  - `test_initialize_filesystem_loads_existing`: Tests that an existing filesystem is loaded from a file.

## Branch
- `test/lib_dir_file_and_main`

## How to Test
1. Run `cargo test` to execute all tests and ensure they pass.
2. Verify that all tests are isolated and use unique filenames.

## Notes
- Ensure the working directory is clean to avoid issues with leftover test files.
- These tests help ensure the reliability and stability of the in-memory filesystem implementation.